### PR TITLE
ユーザープロフィール編集ページ

### DIFF
--- a/app/assets/stylesheets/_sections.scss
+++ b/app/assets/stylesheets/_sections.scss
@@ -93,3 +93,57 @@
     }
   }
 }
+
+.l-chapter-container:first-child{
+  margin: 0;
+  background: #fff;
+  &__head{
+    border-bottom: 1px solid #f5f5f5;
+    text-align: center;
+  }
+}
+.setting-profile-icon{
+  padding: 72px 16px 24px;
+  background-image: url("http://blogimg.goo.ne.jp/user_image/0f/99/24f9145ed5ca6b5aa8885f3b3d606bd2.png");
+  background-repeat: no-repear;
+  background-size: cover;
+  text-align: center;
+  font-size: 0;
+  figure{
+    display: inline-block;
+    overflow: hidden;
+    width: 60px;
+    height: 60px;
+    border-radius: 50%;
+    vertical-align: middle;
+    img{
+      vertical-align: middle;
+      width: 60px;
+      height: 60px;
+    }
+  }
+  .input-default{
+    width: 220px;
+    margin:0 0 0 8px;
+    vertical-align: middle;
+  }
+}
+.setting-profile-content{
+  padding: 40px 16px;
+  .textarea-default{
+    min-height: 216px;
+  }
+  .btn-red{
+  margin: 16px 0 0;
+  }
+}
+.textarea-default{
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  padding: 10px;
+  border: 1px solid #ccc;
+  background: #fff;
+  font-size: 16px;
+  line-height: 1.5;
+}

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,0 +1,18 @@
+.default-container
+  = render 'shared/header'
+  = render 'shared/nav'
+  %main.l-container.clearfix
+    .l-content
+      %section.l-chapter-container
+        %h2.l-chapter-container__head プロフィール
+        %form
+          .setting-profile-icon
+            %figure
+              = image_tag 'member_photo_noimage_thumb.png'
+            %input.input-default{placeholder: '例)AYA☆セール中', type: 'text'}
+          .setting-profile-content
+            %textarea.textarea-default{placeholder: '例）こんにちは☆ ご覧いただきありがとうございます！かわいいものやきれいめオフィスカジュアル中心に出品しています。服のサイズは主に9号です。気持ちよくお取引できるよう心がけていますので、商品や発送方法などご質問がありましたらお気軽にどうぞ♪', type: 'text'}
+            %button.btn-default.btn-red 変更する
+    .l-side
+      = render 'shared/side'
+  = render 'shared/footer'


### PR DESCRIPTION
# キャプチャ画面
https://gyazo.com/fe0f09d06b1e8db3c46e44f662eb7979

# What
ユーザーのプロフィール編集ページのViewの実装

# Why
サービスのUXUI向上のため実装した
ヘッダー, サイドバー, フッターに関してはこれまで実装した内容と同様なので,部分テンプレートで表示している