### PR TITLE
【サーバサイド】商品詳細表示

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ group :development, :test do
   gem 'rspec-rails', '~> 3.5'
   gem 'rails-controller-testing'
   gem 'factory_girl_rails', "~> 4.4.1"
-  gem 'faker'
+  gem 'faker', :git => 'https://github.com/stympy/faker.git', :branch => 'master'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/stympy/faker.git
+  revision: 7277a9d224a9735ea31624411d94c006c7f0fa48
+  branch: master
+  specs:
+    faker (1.9.1)
+      i18n (>= 0.7)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -52,9 +60,8 @@ GEM
       i18n
       rake (>= 10.0.0)
       sshkit (>= 1.9.0)
-    capistrano-bundler (1.4.0)
+    capistrano-bundler (1.5.0)
       capistrano (~> 3.1)
-      sshkit (~> 1.2)
     capistrano-rails (1.4.0)
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
@@ -98,8 +105,6 @@ GEM
     factory_girl_rails (4.4.1)
       factory_girl (~> 4.4.0)
       railties (>= 3.0.0)
-    faker (1.9.1)
-      i18n (>= 0.7)
     ffi (1.9.25)
     font-awesome-rails (4.7.0.4)
       railties (>= 3.2, < 6.0)
@@ -285,7 +290,7 @@ DEPENDENCIES
   devise
   erb2haml
   factory_girl_rails (~> 4.4.1)
-  faker
+  faker!
   font-awesome-rails
   haml-rails
   jbuilder (~> 2.5)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -8,6 +8,6 @@ class ItemsController < ApplicationController
 
   def show
     @item = Item.find(params[:id])
-    @items = Item.where.not(id: @item.id).limit(6)
+    @items = Item.where.not(id: @item.id).order("RAND()").limit(6)
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -7,5 +7,7 @@ class ItemsController < ApplicationController
   end
 
   def show
+    @item = Item.find(params[:id])
+    @items = Item.where.not(id: @item.id).limit(6)
   end
 end

--- a/app/views/items/_item.html.haml
+++ b/app/views/items/_item.html.haml
@@ -1,13 +1,14 @@
 %section.items-box
-  %figure.items-box__photo
-    = image_tag "#{item.images.first.image}"
-  .items-box__body
-    %h3.items-box__body__name.font-2
-      = item.name
-    .items-box__body__num.clearfix
-      .items-box__body__num__price.font-5
-        = item.price
-      .items-box__body__num__likes.font-2
-        = fa_icon 'heart', class: 'icon-like-border'
-        %span 0
-      %p.items-box__body__num__tax (税込)
+  = link_to item_path(item) do
+    %figure.items-box__photo
+      = image_tag "#{item.images.first.image}"
+    .items-box__body
+      %h3.items-box__body__name.font-2
+        = item.name
+      .items-box__body__num.clearfix
+        .items-box__body__num__price.font-5
+          = item.price
+        .items-box__body__num__likes.font-2
+          = fa_icon 'heart', class: 'icon-like-border'
+          %span 0
+        %p.items-box__body__num__tax (税込)

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -2,7 +2,8 @@
   = render 'shared/header'
   = render 'shared/nav'
   %section.l-single-container.item-box-container
-    %h1.item_name パーカー
+    %h1.item_name
+      = @item.name
     .item-main-content.clearfix
       .item-photo
         .owl-carousel.owl-loaded.owl-drag
@@ -10,14 +11,15 @@
             .owl-stage{style: "left:0px; width: 1200px;"}
               .owl-item{style: "width: 300px;"}
                 .owl-item-inner.is-higher-width
-                  = image_tag "sample_item.jpg",class: 'owl-lazy',style: "opacity: 1;"
+                  = image_tag "#{@item.images.first.image}",class: 'owl-lazy',style: "opacity: 1;"
       %table.item-detail-table
         %tbody
           %tr
             %th
               出品者
             %td
-              %a だいまる♡
+              %a
+                = @item.user.nickname
               %div
                 %div.item-user-ratings
                   = fa_icon 'smile', class: 'icon-good'
@@ -52,58 +54,43 @@
             %th
               商品のサイズ
             %td
-              FREE SIZE
+              = @item.size
           %tr
             %th
               商品の状態
             %td
-              未使用に近い
+              = @item.condition
           %tr
             %th
               配送者の負担
             %td
-              送料込み(出品者負担)
+              = @item.delivery_burden
           %tr
             %th
               配送の方法
             %td
-              ゆうゆうメルカリ便
+              = @item.delivery_method
           %tr
             %th
               配送元地域
             %td
-              未定
+              = @item.delivery_from
           %tr
             %th
               発送日の目安
             %td
-              4~7日で発送
+              = @item.delivery_days
+              日
     .item-price-box.text-center
-      %span.item-price.bold ¥ 9,900
+      %span.item-price.bold
+        ¥
+        = @item.price
       %span.item-tax (税込)
       %span.item-shipping-fee 送料込み
     %a.item-buy-btn.f18-24 購入画面に進む
     .item-description.f14
       %p.item-description__inner
-        購入して試着のみの美品です(^-^)
-
-        ホームクリーニング済み
-        サイズ フリー
-
-        ＃レース と #ビジュー がとっても可愛いです♡
-
-        ＃AW #秋冬 #ドレス #結婚式 #おしゃれ #パール #お呼ばれ服 #パーティー
-
-
-        お値下げは不可です。
-        この金額で購入して下さる方お願い致します。
-
-        ✽.。.:*・゜ ✽.。.:*・゜ ✽.。.:*・゜ ✽.。.:*・゜ ✽.。.:*・゜
-        エミリアウィズ ジルスチュアート イング アラマンダ
-        ロディスポット マーキュリーデュオ リズリサ
-        シークレットハニー ハニーサロン リリーブラウン
-        レッセパッセ アプワイザーリッシェ Rady
-        など好きな方も是非♡
+        = @item.description
     .item-button-container.clearfix
       .item-button-left
         %button.item-button.item-button__like
@@ -148,84 +135,9 @@
   .items-in-user-profile
     %section.items-box-container.clearfix.items-box-overflow.items-in-user-profile
       %h2.items-box-head
-        %a だいまる♡さんのその他の商品
+        %a
+          = @item.user.nickname
+          さんのその他の商品
       .items-box-content.clearfix
-        %section.items-box
-          %figure.items-box__photo
-            = image_tag "sample_item.jpg"
-          .items-box__body
-            %h3.items-box__body__name.font-2
-              けいいちろう
-            .items-box__body__num.clearfix
-              .items-box__body__num__price.font-5
-                600
-              .items-box__body__num__likes.font-2
-                = fa_icon 'heart', class: 'icon-like-border'
-                %span 0
-              %p.items-box__body__num__tax (税込)
-        %section.items-box
-          %figure.items-box__photo
-            = image_tag "sample_item.jpg"
-          .items-box__body
-            %h3.items-box__body__name.font-2
-              けいいちろう
-            .items-box__body__num.clearfix
-              .items-box__body__num__price.font-5
-                600
-              .items-box__body__num__likes.font-2
-                = fa_icon 'heart', class: 'icon-like-border'
-                %span 0
-              %p.items-box__body__num__tax (税込)
-        %section.items-box
-          %figure.items-box__photo
-            = image_tag "sample_item.jpg"
-          .items-box__body
-            %h3.items-box__body__name.font-2
-              けいいちろう
-            .items-box__body__num.clearfix
-              .items-box__body__num__price.font-5
-                600
-              .items-box__body__num__likes.font-2
-                = fa_icon 'heart', class: 'icon-like-border'
-                %span 0
-              %p.items-box__body__num__tax (税込)
-        %section.items-box
-          %figure.items-box__photo
-            = image_tag "sample_item.jpg"
-          .items-box__body
-            %h3.items-box__body__name.font-2
-              けいいちろう
-            .items-box__body__num.clearfix
-              .items-box__body__num__price.font-5
-                600
-              .items-box__body__num__likes.font-2
-                = fa_icon 'heart', class: 'icon-like-border'
-                %span 0
-              %p.items-box__body__num__tax (税込)
-        %section.items-box
-          %figure.items-box__photo
-            = image_tag "sample_item.jpg"
-          .items-box__body
-            %h3.items-box__body__name.font-2
-              けいいちろう
-            .items-box__body__num.clearfix
-              .items-box__body__num__price.font-5
-                600
-              .items-box__body__num__likes.font-2
-                = fa_icon 'heart', class: 'icon-like-border'
-                %span 0
-              %p.items-box__body__num__tax (税込)
-        %section.items-box
-          %figure.items-box__photo
-            = image_tag "sample_item.jpg"
-          .items-box__body
-            %h3.items-box__body__name.font-2
-              けいいちろう
-            .items-box__body__num.clearfix
-              .items-box__body__num__price.font-5
-                600
-              .items-box__body__num__likes.font-2
-                = fa_icon 'heart', class: 'icon-like-border'
-                %span 0
-              %p.items-box__body__num__tax (税込)
+        = render @items
   = render 'shared/footer'

--- a/db/migrate/20181227011049_add_columns_to_items.rb
+++ b/db/migrate/20181227011049_add_columns_to_items.rb
@@ -1,0 +1,7 @@
+class AddColumnsToItems < ActiveRecord::Migration[5.0]
+  def change
+    add_column :items, :delivery_burden, :string, null: false
+    add_column :items, :delivery_from, :string, null: false
+    add_column :items, :size, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181217074637) do
+ActiveRecord::Schema.define(version: 20181227011049) do
 
   create_table "images", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "image",      null: false
@@ -31,6 +31,9 @@ ActiveRecord::Schema.define(version: 20181217074637) do
     t.integer  "user_id"
     t.datetime "created_at",                    null: false
     t.datetime "updated_at",                    null: false
+    t.string   "delivery_burden",               null: false
+    t.string   "delivery_from",                 null: false
+    t.string   "size",                          null: false
     t.index ["name"], name: "index_items_on_name", using: :btree
     t.index ["user_id"], name: "index_items_on_user_id", using: :btree
   end

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -9,8 +9,32 @@ describe ItemsController do
         get :index
       end
 
-      it 'redners index' do
+      it 'renders index' do
         expect(response).to render_template :index
+      end
+    end
+
+    context 'not log in' do
+      before do
+        get :index
+      end
+
+      it 'redirects to new_user_session_path' do
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe 'GET #show' do
+    context 'log in' do
+      before do
+        login user
+        get :index
+      end
+      it "renders the :show template" do
+        item = create(:item)
+        get :show, id: item
+        expect(response).to render_template :show
       end
     end
 

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,6 +1,13 @@
 FactoryGirl.define do
   factory :item do
-    name Faker::String.random(6..19)
-    price rand(201..9999999)
+    name "テスト"
+    description "テスト"
+    condition "目立った傷や汚れなし"
+    delivery_method "らくらくメルカリ便"
+    delivery_days "3"
+    price "2000"
+    delivery_burden "送料込み(出品者負担)"
+    delivery_from "東京"
+    size "フリーサイズ"
   end
 end


### PR DESCRIPTION
# キャプチャ画面
https://gyazo.com/e58099e153ee451272053e489fc99c63
単体テスト検証
https://gyazo.com/7cf8e196e2187eb09e11e67485eceb12

# what
Itemテーブルから商品情報を抽出し、商品詳細ページで表示させた
・items_controllerのshowメソッドにコードを記述
・商品詳細ページを、商品情報と出品者の商品を表示する様に編集
・別ページから商品詳細ページへアクセスできる様に、_item.html.hamlの全体をリンク化
・itemテーブルに対し、商品サイズ、配送元地域、発送者の負担のカラムが存在しなかったので追加
・showページか表示されるか,単体テストで検証
・fakerを用いた商品のダミーデータを作成

# why
サービスのUX向上のため実装した